### PR TITLE
Trello Card 84: prevent random boss + Unlock Kefka requirements from softlocks

### DIFF
--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -188,7 +188,7 @@ class EnemyPacks():
             all_boss_formations = set(bosses.normal_formation_name)
             # remaining bosses is all bosses - required bosses | required statues
             required_formations = set(required_boss_formations | required_statue_formations)
-            remaining_boss_formations = list(all_boss_formations - required_formations)
+            remaining_boss_formations = sorted(all_boss_formations - required_formations)
             # the random boss formation list is a sample of the remaining bosses for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
             # update required boss formations with union of itself & random boss formations
@@ -207,7 +207,7 @@ class EnemyPacks():
         dragon_formations_needed = min_dragon_formations - len(required_dragon_formations)
         if dragon_formations_needed > 0:
             all_dragon_formations = set(bosses.dragon_formation_name)
-            remaining_dragon_formations = list(all_dragon_formations - required_dragon_formations)
+            remaining_dragon_formations = sorted(all_dragon_formations - required_dragon_formations)
             random_dragon_formations = random.sample(remaining_dragon_formations, dragon_formations_needed)
             required_dragon_formations |= set(random_dragon_formations)
 

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -150,9 +150,11 @@ class EnemyPacks():
         from constants.objectives.conditions import names as possible_condition_names
 
         boss_condition_name = "Boss"
+        bosses_condition_name = "Bosses"
         dragon_condition_name = "Dragon"
         dragons_condition_name = "Dragons"
         assert boss_condition_name in possible_condition_names
+        assert bosses_condition_name in possible_condition_names
         assert dragon_condition_name in possible_condition_names
         assert dragons_condition_name in possible_condition_names
 
@@ -160,6 +162,7 @@ class EnemyPacks():
         required_dragon_formations = set()
         required_statue_formations = set()
 
+        min_boss_formations = 0
         min_dragon_formations = 0
         for objective in objectives:
             for condition in objective.conditions:
@@ -169,10 +172,37 @@ class EnemyPacks():
                         required_statue_formations.add(formation)
                     else:
                         required_boss_formations.add(formation)
+                # if this condition is a set number of bosses, make sure we always get the highest amount for the minimum req # of formations
+                elif condition.NAME == bosses_condition_name and condition.count > min_boss_formations:
+                    min_boss_formations = condition.count
                 elif condition.NAME == dragon_condition_name:
                     required_dragon_formations.add(condition.dragon_formation)
                 elif condition.NAME == dragons_condition_name and condition.count > min_dragon_formations:
                     min_dragon_formations = condition.count
+
+        # amount of bosses needed is the minimum from above minus the required bosses + required statues
+        boss_formations_needed = min_boss_formations - (len(required_boss_formations) + len(required_statue_formations))
+        # if the extra required number needed non-zero
+        if boss_formations_needed > 0:
+            # initialize all boss formations set
+            all_boss_formations = set(bosses.normal_formation_name)
+            # remaining bosses is all bosses - required bosses | required statues
+            required_formations = set(required_boss_formations | required_statue_formations)
+            remaining_boss_formations = list(all_boss_formations - required_formations)
+            # the random boss formation list is a sample of the remaining bosses for the amount needed to fulfill objectives
+            random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
+            # update required boss formations with union of itself & random boss formations
+            required_boss_formations |= set(random_boss_formations)
+            # now we need to separate out any statues that are in the required boss formations at the end
+            for formation_id in random_boss_formations:
+                # if this formation is a statue
+                if formation_id in bosses.statue_formation_name:
+                    # remove from regular boss formations
+                    required_boss_formations.remove(formation_id)
+                    # if the formation not currently in the required set
+                    if formation_id not in required_statue_formations:
+                        # add into statue formations
+                        required_statue_formations.add(formation_id)
 
         dragon_formations_needed = min_dragon_formations - len(required_dragon_formations)
         if dragon_formations_needed > 0:

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -191,18 +191,17 @@ class EnemyPacks():
             remaining_boss_formations = sorted(all_boss_formations - required_formations)
             # the random boss formation list is a sample of the remaining bosses for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
-            # update required boss formations with union of itself & random boss formations
-            required_boss_formations |= set(random_boss_formations)
-            # now we need to separate out any statues that are in the required boss formations at the end
+            # add these boss formations into the appropriate set 
+            # (required_boss_formations or required_statue_formations)
             for formation_id in random_boss_formations:
                 # if this formation is a statue
                 if formation_id in bosses.statue_formation_name:
-                    # remove from regular boss formations
-                    required_boss_formations.remove(formation_id)
-                    # if the formation not currently in the required set
-                    if formation_id not in required_statue_formations:
-                        # add into statue formations
-                        required_statue_formations.add(formation_id)
+                    # add to required statue formations
+                    required_statue_formations.add(formation_id)
+                # else a regular boss
+                else:
+                    # add to required boss formations
+                    required_boss_formations.add(formation_id)
 
         dragon_formations_needed = min_dragon_formations - len(required_dragon_formations)
         if dragon_formations_needed > 0:
@@ -250,6 +249,13 @@ class EnemyPacks():
             self.event_boss_replacements[boss] = random.choice(bosses_possible)
 
         self.phunbaba3_safety_check(bosses_possible)
+
+        print(len(required_boss_formations))
+        print(len(required_statue_formations))
+        for boss in required_boss_formations:
+            print("Normal:", bosses.normal_formation_name[boss])
+        for boss in required_statue_formations:
+            print("Statue:", bosses.normal_formation_name[boss])
 
     def randomize_packs(self, packs, boss_percent, no_phunbaba3 = False):
         exclude_bosses = []

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -250,13 +250,6 @@ class EnemyPacks():
 
         self.phunbaba3_safety_check(bosses_possible)
 
-        print(len(required_boss_formations))
-        print(len(required_statue_formations))
-        for boss in required_boss_formations:
-            print("Normal:", bosses.normal_formation_name[boss])
-        for boss in required_statue_formations:
-            print("Statue:", bosses.normal_formation_name[boss])
-
     def randomize_packs(self, packs, boss_percent, no_phunbaba3 = False):
         exclude_bosses = []
         if no_phunbaba3 or not self.args.shuffle_random_phunbaba3:


### PR DESCRIPTION
From Trello: https://trello.com/c/Ot3toGC8/84-prevent-softlock-scenarios-for-kefka-unlock-requirements-with-unique-bosses-dragons-killed

Dragon softlock prevention was already in place, but somehow bosses/statues were left out. This PR attempts to prevent a scenario where the Bosses = Random and Kefka requires a specific number of bosses for unlock. If this number is very high, there is a possibility that the randomizer doesn't put in enough unique bosses to actually beat the game by unlocking Kefka objective remaining incomplete.

**Testing:**
Wrote code in `enemy_packs.py` to print out the required boss & statue fights:
```
        print(len(required_boss_formations))
        print(len(required_statue_formations))
        for boss in required_boss_formations:
            print(bosses.normal_formation_name[boss])
        for boss in required_statue_formations:
            print(bosses.normal_formation_name[boss])
```



_Final Kefka objective = 4 bosses + Doom required_
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.4.4.2.12.12.4.24.24.8.4.4.9.6 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -oe 3.1.1.9.6 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
	Required Bosses: 3
	Required Statues: 1
	Vargas
	Rizopas
	Dullahan
	Doom
_Final Kefka objective = 34 bosses + Air Force + Goddess (ensure 1 non-statue boss & 1 statue boss)_
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.5.5.2.12.12.4.24.24.8.34.34.9.0.9.11 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -oe 3.1.1.9.6 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
	Required Bosses: 31
	Required Statues: 3
Marshal
Phunbaba 3
Phunbaba 4
Whelk
Vargas
TunnelArmr
GhostTrain
Dadaluma
Ifrit/Shiva
Cranes
Number 024
Number 128
Umaro
Guardian
FlameEater
Nerapa
SrBehemoth
Tentacles
Dullahan
Chadarnook
Air Force
Wrexsoul
Rizopas
Hidon
Doom Gaze
Ultros 1
Ultros/Chupon
Atma
MagiMaster
Tritoch
Kefka (Narshe)
Doom
Goddess
Poltrgeist

_Doing it another time gave me 32/2:_
32
2
Ultros 3
Leader
Phunbaba 3
Phunbaba 4
Whelk
TunnelArmr
GhostTrain
Dadaluma
Ifrit/Shiva
Cranes
Number 024
Number 128
Umaro
Guardian
FlameEater
Nerapa
SrBehemoth
Tentacles
Dullahan
Air Force
Stooges
Wrexsoul
Doom Gaze
Rizopas
Hidon
Ultros 1
Ultros 2
Ultros/Chupon
MagiMaster
Inferno
Tritoch
Kefka (Narshe)
Doom
Goddess

_Final Kefka objective = 2 bosses + Guardian + Dadaluma + Poltrgeist (# bosses < # named bosses)_
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.6.6.2.12.12.4.24.24.8.2.2.9.5.9.24.9.12 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
2
1
Guardian
Dadaluma
Poltrgeist